### PR TITLE
fix error 137 when reboot computer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ADD config/stop-yarn.sh $HADOOP_HOME/sbin
 
 RUN echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $HADOOP_HOME/etc/hadoop/hadoop-env.sh
 
-#ENV PATH $HADOOP_HOME/bin:$PATH
+ENV PATH $HADOOP_HOME/bin:$PATH
 RUN /bin/bash -c "source ~/.bashrc"
 
 
@@ -58,6 +58,7 @@ ENV PIG_HOME /usr/local/pig
 ENV PATH $PIG_HOME/bin:$PATH
 ENV PIG_CLASSPATH $HADOOP_CONF_DIR
 RUN /bin/bash -c "source ~/.bashrc"
-
+ARG FORMAT_NAMENODE_COMMAND
+RUN $FORMAT_NAMENODE_COMMAND
 #RUN mkdir /var/run/sshd
 EXPOSE 22

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     build:
       context: .
       shm_size: '2gb'
+      args: 
+           FORMAT_NAMENODE_COMMAND: hdfs namenode -format
     container_name: master
     networks:
       default:
@@ -47,9 +49,9 @@ services:
       slave1: 172.16.0.3
       slave2: 172.16.0.4
     command: bash -c  "
-        hdfs namenode -format 
-        && start-dfs.sh
+        start-dfs.sh
         && start-yarn.sh
+        && mr-jobhistory-daemon.sh start historyserver
         && tail -f /dev/null"
     ports:
       - 50070:50070


### PR DESCRIPTION
ERROR
-
- When reboot computer: all container was exited code with 137 because the name node was **formatted againt**, so all daemon in hadoop was stopped.

FIX
-
- Add arg **NAMENODE_FORMAT_COMMAND** of master service in **_docker-compose_**, and use this arg in **_Dockerfile_** to format namenode **only one time**.

